### PR TITLE
Unlock tips instantly

### DIFF
--- a/contracts/yGift/yGift.sol
+++ b/contracts/yGift/yGift.sol
@@ -38,8 +38,6 @@ contract yGift is ERC721("yearn Gift NFT", "yGIFT") {
 	 * _start: the amount of time the gift will be locked until the recipient can collect it   
 	 * _duration: duration over which the amount linearly becomes available  *
 	 *
-	 * requirement: only a whitelisted minter can call this function
-	 *
 	 * Emits a {Tip} event.
 	 */
 	function mint(
@@ -94,7 +92,6 @@ contract yGift is ERC721("yearn Gift NFT", "yGIFT") {
 	 * _amount: amount of tokens in the gift
 	 * _start: Time at which the cliff ends
 	 * _duration: vesting period
-	 *
 	 */
 	function available(uint _amount, uint _start, uint _duration) public view returns (uint) {
 		if (_start > block.timestamp) return 0;
@@ -103,11 +100,20 @@ contract yGift is ERC721("yearn Gift NFT", "yGIFT") {
 	}
 
 	/**
+	 * @dev Returns the maximum collectible amount of tokens for a given gift
+	 * _tokenId: gift for which to calculate the collectibe amount
+	 */
+	function collectible(uint _tokenId) public view returns (uint) {
+		Gift storage gift = gifts[_tokenId];
+		return available(gift.amount, gift.start, gift.duration).add(gift.tipped);
+	}
+
+	/**
 	 * @dev Allows the gift recipient to collect their tokens
 	 * _tokenId: gift in which the function caller would like to tip
 	 * _amount: amount of tokens the gift owner would like to collect
 	 *
-	 * requirement: caller must own the gift recipient && gift must have been redeemed
+	 * requirement: caller must be the owner of the gift
 	 */
 	function collect(uint _tokenId, uint _amount) public {
 		require(_isApprovedOrOwner(msg.sender, _tokenId), "yGift: You are not the NFT owner");

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -31,6 +31,8 @@ def test_tip(ygift, token, giftee, chain):
     assert gift["amount"] == amount
     assert gift["tipped"] == amount
     # tips are available instantly
+    chain.mine()
+    assert ygift.collectible(0) >= amount
     ygift.collect(0, amount, {'from': giftee})
     assert token.balanceOf(giftee) >= amount
 

--- a/tests/test_operation.py
+++ b/tests/test_operation.py
@@ -15,6 +15,7 @@ def test_mint(ygift, token, giftee, chain):
         "message": "msg",
         "url": "url",
         "amount": amount,
+        "tipped": 0,
         "start": start,
         "duration": duration,
     }
@@ -24,10 +25,14 @@ def test_tip(ygift, token, giftee, chain):
     amount = Wei("1000 ether")
     start = chain[-1].timestamp
     token.approve(ygift, 2 ** 256 - 1)
-    ygift.mint(giftee, token, amount, "name", "msg", "url", start, 0)
+    ygift.mint(giftee, token, amount, "name", "msg", "url", start, 1000)
     ygift.tip(0, amount, "tip")
     gift = ygift.gifts(0).dict()
-    assert gift["amount"] == amount * 2
+    assert gift["amount"] == amount
+    assert gift["tipped"] == amount
+    # tips are available instantly
+    ygift.collect(0, amount, {'from': giftee})
+    assert token.balanceOf(giftee) >= amount
 
 
 def test_tip_nonexistent(ygift, token):


### PR DESCRIPTION
Separate tips from vested amount.

Change `collect` behavior to tap into `tipped` first, `amount` second.

`available()` is unchanged, use it to calculate vested amount.

The full collectible amount is now `available` + `gift.tipped`

Add a helper view `collectible(_tokenId)` which returns max collectible amount.